### PR TITLE
Fix game start

### DIFF
--- a/Assets/Scripts/AvatarController.cs
+++ b/Assets/Scripts/AvatarController.cs
@@ -14,7 +14,7 @@ public class AvatarController : MonoBehaviourPunCallbacks
         //     transform.Translate(moveVector * moveSpeed * Time.deltaTime, Space.World);
         // }   
         // 自身が生成したオブジェクトだけに移動処理を行う
-        if (photonView.IsMine) {
+        if (photonView.IsMine && GameState.m_gameState == GameState.e_GameState.Game) {
             var input = new Vector3(Input.GetAxis("Horizontal"), 0f, Input.GetAxis("Vertical"));
             if (input != Vector3.zero)
             {

--- a/Assets/Scripts/MainController.cs
+++ b/Assets/Scripts/MainController.cs
@@ -92,8 +92,8 @@ public class MainController : MonoBehaviourPunCallbacks, IPunObservable
             isEnableStart = false;
         }
 
-        Debug.Log(customProperties["GameState"]);
-        Debug.Log("Get: " + GameState.GetGameState());
+        //Debug.Log(customProperties["GameState"]);
+        //Debug.Log("Get: " + GameState.GetGameState());
         /*
          * customPropはMactting→GameStartに変化0→1
          * GameStateはMacttingのまま変化しない
@@ -102,8 +102,8 @@ public class MainController : MonoBehaviourPunCallbacks, IPunObservable
         /* でも, masterClient以外このif分は処理されない
          * なんで??
          */
-        //if (GameState.e_GameState.GameStart.Equals(customProperties["GameState"]))
-        if (1 == ((customProperties["GameState"] is int value) ? value : 0))
+        if (GameState.e_GameState.GameStart.Equals((GameState.e_GameState)customProperties["GameState"]))
+        //if (GameState.e_GameState.GameStart == ((customProperties["GameState"] is GameState.e_GameState value) ? value : 0))
         {
             GameStartProcess();
             Debug.Log("started GameState Get: " + GameState.GetGameState());

--- a/Assets/Scripts/MainController.cs
+++ b/Assets/Scripts/MainController.cs
@@ -102,7 +102,8 @@ public class MainController : MonoBehaviourPunCallbacks, IPunObservable
         /* でも, masterClient以外このif分は処理されない
          * なんで??
          */
-        if (GameState.e_GameState.GameStart.Equals(customProperties["GameState"]))
+        //if (GameState.e_GameState.GameStart.Equals(customProperties["GameState"]))
+        if (1 == ((customProperties["GameState"] is int value) ? value : 0))
         {
             GameStartProcess();
             Debug.Log("started GameState Get: " + GameState.GetGameState());

--- a/Assets/Scripts/MainController.cs
+++ b/Assets/Scripts/MainController.cs
@@ -103,7 +103,7 @@ public class MainController : MonoBehaviourPunCallbacks, IPunObservable
          * なんで??
          */
         //if (GameState.e_GameState.GameStart.Equals((GameState.e_GameState)customProperties["GameState"]))
-        if (GameState.e_GameState.GameStart == ((customProperties["GameState"] is GameState.e_GameState value) ? value : 0))
+        if (GameState.e_GameState.GameStart.Equals((customProperties["GameState"] is object value) ? value : 0))
         {
             GameStartProcess();
             Debug.Log("started GameState Get: " + GameState.GetGameState());

--- a/Assets/Scripts/MainController.cs
+++ b/Assets/Scripts/MainController.cs
@@ -102,8 +102,7 @@ public class MainController : MonoBehaviourPunCallbacks, IPunObservable
         /* でも, masterClient以外このif分は処理されない
          * なんで??
          */
-        //if (GameState.e_GameState.GameStart.Equals((GameState.e_GameState)customProperties["GameState"]))
-        if (GameState.e_GameState.GameStart.Equals((customProperties["GameState"] is object value) ? value : 0))
+        if (GameState.e_GameState.GameStart == (GameState.e_GameState)customProperties["GameState"])
         {
             GameStartProcess();
             Debug.Log("started GameState Get: " + GameState.GetGameState());

--- a/Assets/Scripts/MainController.cs
+++ b/Assets/Scripts/MainController.cs
@@ -102,8 +102,8 @@ public class MainController : MonoBehaviourPunCallbacks, IPunObservable
         /* でも, masterClient以外このif分は処理されない
          * なんで??
          */
-        if (GameState.e_GameState.GameStart.Equals((GameState.e_GameState)customProperties["GameState"]))
-        //if (GameState.e_GameState.GameStart == ((customProperties["GameState"] is GameState.e_GameState value) ? value : 0))
+        //if (GameState.e_GameState.GameStart.Equals((GameState.e_GameState)customProperties["GameState"]))
+        if (GameState.e_GameState.GameStart == ((customProperties["GameState"] is GameState.e_GameState value) ? value : 0))
         {
             GameStartProcess();
             Debug.Log("started GameState Get: " + GameState.GetGameState());

--- a/Assets/Scripts/MainController.cs
+++ b/Assets/Scripts/MainController.cs
@@ -116,7 +116,7 @@ public class MainController : MonoBehaviourPunCallbacks, IPunObservable
         UpdateRoomCustomProperties(playerCnt);
 
         // startBtn起動
-        if (playerCnt == 4)
+        if (playerCnt > 1)
         {
             isEnableStart = true;
         }
@@ -133,7 +133,7 @@ public class MainController : MonoBehaviourPunCallbacks, IPunObservable
         UpdateRoomCustomProperties(playerCnt);
 
         // startBtn不可
-        if (playerCnt != 4)
+        if (playerCnt == 1)
         {
             isEnableStart = false;
             if (PhotonNetwork.IsMasterClient)

--- a/Assets/Scripts/MenuController.cs
+++ b/Assets/Scripts/MenuController.cs
@@ -61,7 +61,7 @@ public class MenuController : MonoBehaviourPunCallbacks
         Debug.Log("ルームに参加しました");
 
         PhotonNetwork.IsMessageQueueRunning = false;
-        //SceneManager.LoadSceneAsync("SampleJoystick", LoadSceneMode.Single);
+        GameState.SetGameState(GameState.e_GameState.Mactting);
         SceneManager.LoadSceneAsync("MainGameScene", LoadSceneMode.Single);
     }
 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -11,7 +11,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/MainGameScene.unity
     guid: 6d0d4446f0a7145749d52638c2dcad5c
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/SampleJoystick.unity
     guid: 893a3a86b8b624bb28c76af387f8e1c8
   m_configObjects: {}


### PR DESCRIPTION
GameStateを用いたGameStartの同期.
GameStart前後でのWASDでの移動を制限.